### PR TITLE
Changed phone format for Sweden

### DIFF
--- a/src/country_data.js
+++ b/src/country_data.js
@@ -1277,7 +1277,7 @@ const rawAllCountries = [
     ['europe', 'european-union'],
     'se',
     '46',
-    '+.. (...) ...-...',
+    '+.. (..) ...-..-..',
   ],
   [
     'Switzerland',


### PR DESCRIPTION
Changed phone format from +46 (xxx) xxx-xxx to +46 (xx) xxx-xx-xx