### PR TITLE
Move classnames package to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,11 +54,11 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
+    "classnames": "^2.2.6",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "@material-ui/core": "^4.2.1",
-    "classnames": "^2.2.6",
     "lodash": "^4.17.14",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"


### PR DESCRIPTION
When installing material-ui-phone-number (using the recommended command of `npm install material-ui-phone-number --save`), I get the following error:

```
Failed to compile.

./node_modules/material-ui-phone-number/dist/index.js
Module not found: Can't resolve 'classnames' in 'C:\path\to\project\node_modules\material-ui-phone-number\dist'
```

This is because classnames is required in index.js but is not automatically installed as it is only a peer dependency. I'm not sure why this is the case - it seems to have been changed in 205043cb8db72e1ba9a120ee2fd4d7ff979a746c. I've gone ahead and moved it from peerDependencies to dependencies.