### PR TITLE
Update some African number formats

### DIFF
--- a/src/country_data.js
+++ b/src/country_data.js
@@ -152,6 +152,7 @@ const rawAllCountries = [
     ['africa'],
     'bj',
     '229',
+    '+... .... ....',
   ],
   [
     'Bermuda',
@@ -219,12 +220,14 @@ const rawAllCountries = [
     ['africa'],
     'bf',
     '226',
+    '+... .. .. .. ..',
   ],
   [
     'Burundi',
     ['africa'],
     'bi',
     '257',
+    '+... .. .. .. ..',
   ],
   [
     'Cambodia',
@@ -251,6 +254,7 @@ const rawAllCountries = [
     ['africa'],
     'cv',
     '238',
+    '+... ... .. ..',
   ],
   [
     'Caribbean Netherlands',
@@ -271,12 +275,14 @@ const rawAllCountries = [
     ['africa'],
     'cf',
     '236',
+    '+... .... ....',
   ],
   [
     'Chad',
     ['africa'],
     'td',
     '235',
+    '+... .. .. .. ..',
   ],
   [
     'Chile',
@@ -302,6 +308,7 @@ const rawAllCountries = [
     ['africa'],
     'km',
     '269',
+    '+... ... ....',
   ],
   [
     'Congo',
@@ -314,6 +321,7 @@ const rawAllCountries = [
     ['africa'],
     'cg',
     '242',
+    '+... .. .. .....',
   ],
   [
     'Cook Islands',
@@ -333,6 +341,7 @@ const rawAllCountries = [
     ['africa'],
     'ci',
     '225',
+    '+... .. .. .. ..',
   ],
   [
     'Croatia',
@@ -418,6 +427,7 @@ const rawAllCountries = [
     ['africa'],
     'gq',
     '240',
+    '+... .. ... ....',
   ],
   [
     'Eritrea',
@@ -487,6 +497,7 @@ const rawAllCountries = [
     ['africa'],
     'ga',
     '241',
+    '+... .. .. .. ..',
   ],
   [
     'Gambia',
@@ -563,6 +574,7 @@ const rawAllCountries = [
     ['africa'],
     'gn',
     '224',
+    '+... . ... ....',
   ],
   [
     'Guinea-Bissau',
@@ -778,6 +790,7 @@ const rawAllCountries = [
     ['africa'],
     'mg',
     '261',
+    '+... .. .. ... ..',
   ],
   [
     'Malawi',
@@ -803,6 +816,7 @@ const rawAllCountries = [
     ['africa'],
     'ml',
     '223',
+    '+... .... ....',
   ],
   [
     'Malta',
@@ -827,6 +841,7 @@ const rawAllCountries = [
     ['africa'],
     'mr',
     '222',
+    '+... .... ....',
   ],
   [
     'Mauritius',
@@ -882,6 +897,7 @@ const rawAllCountries = [
     ['africa', 'north-africa'],
     'ma',
     '212',
+    '+212-.........',
   ],
   [
     'Mozambique',
@@ -944,6 +960,7 @@ const rawAllCountries = [
     ['africa'],
     'ne',
     '227',
+    '+... .. .. .. ..',
   ],
   [
     'Nigeria',
@@ -1090,6 +1107,7 @@ const rawAllCountries = [
     ['africa'],
     'rw',
     '250',
+    '+... ... ... ...',
   ],
   [
     'Saint Barthélemy',
@@ -1154,6 +1172,7 @@ const rawAllCountries = [
     ['africa'],
     'st',
     '239',
+    '+... ... ....',
   ],
   [
     'Saudi Arabia',
@@ -1166,6 +1185,7 @@ const rawAllCountries = [
     ['africa'],
     'sn',
     '221',
+    '+... .. ... .. ..',
   ],
   [
     'Serbia',
@@ -1178,6 +1198,7 @@ const rawAllCountries = [
     ['africa'],
     'sc',
     '248',
+    '+... . ... ...',
   ],
   [
     'Sierra Leone',
@@ -1227,6 +1248,7 @@ const rawAllCountries = [
     ['africa'],
     'za',
     '27',
+    '+.. .. ... ....',
   ],
   [
     'South Korea',
@@ -1327,6 +1349,7 @@ const rawAllCountries = [
     ['africa'],
     'tg',
     '228',
+    '+... ... .....',
   ],
   [
     'Tokelau',
@@ -1351,6 +1374,7 @@ const rawAllCountries = [
     ['africa', 'north-africa'],
     'tn',
     '216',
+    '+... .. ... ...',
   ],
   [
     'Turkey',


### PR DESCRIPTION
I needed some formats for several countries so I added them to the `country_data.js`
I couldn't find a unique reliable source for the formats, so I looked on Wikipedia pages "Telephone numbers in {Country}" and some random examples found on Google Maps, so feel free to update if one of them is wrong, but it should be ok.

>Affected countries:
>- Benin
>- Burkina Faso
>- Burundi
>- Cape Verde
>- Central African Republic
>- Chad
>- Comoros
>- Congo (+242)
>- Côte d'Ivoire
>- Equatorial Guinea
>- Gabon
>- Guinea
>- Madagascar
>- Mali
>- Mauritania
>- Morocco
>- Niger
>- Rwanda
>- São Tomé and Príncipe
>- Senegal
>- Seychelles
>- South Africa
>- Togo
>- Tunisia