### PR TITLE
Move material-ui from dependencies to peer and dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.5.4",
     "@babel/preset-env": "^7.5.4",
     "@babel/preset-react": "^7.0.0",
+    "@material-ui/core": "^4.2.1",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",
     "babel-plugin-lodash": "^3.3.4",
@@ -54,11 +55,13 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
-    "@material-ui/core": "^4.2.1",
     "clsx": "^1.0.4",
     "lodash": "^4.17.14",
     "prop-types": "^15.7.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
+  },
+  "peerDependencies": {
+    "@material-ui/core": "^4.2.1"
   }
 }


### PR DESCRIPTION
Hey,
I found that to use your project, you're limited to using exactly the same version of Material-UI as the material-ui-phone-number. I think that it's not proper and may cause bugs (for example in my case it crashes the app) so I moved material-ui/core from dependencies to dev and peer dependencies 😄 