### PR TITLE
Fix positioning of the dropdown and show selected

### DIFF
--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -294,37 +294,6 @@ class MaterialUiPhoneNumber extends React.Component {
     };
   }
 
-  handleFlagDropdownClick = () => {
-    const {
-      anchorEl, selectedCountry, preferredCountries, onlyCountries,
-    } = this.state;
-    const { disabled } = this.props;
-
-    if (!anchorEl && disabled) return;
-
-    const highlightCountryIndex = preferredCountries.includes(selectedCountry)
-      ? findIndex(preferredCountries, selectedCountry)
-      : findIndex(onlyCountries, selectedCountry);
-
-    if (preferredCountries.includes(selectedCountry)) {
-      this.setState({
-        highlightCountryIndex,
-      }, () => {
-        if (anchorEl) {
-          this.scrollTo(this.getElement(highlightCountryIndex));
-        }
-      });
-    } else {
-      this.setState({
-        highlightCountryIndex,
-      }, () => {
-        if (anchorEl) {
-          this.scrollTo(this.getElement(highlightCountryIndex + preferredCountries.length));
-        }
-      });
-    }
-  }
-
   handleInput = (e) => {
     let { selectedCountry: newSelectedCountry, freezeSelection } = this.state;
     const {
@@ -619,8 +588,9 @@ class MaterialUiPhoneNumber extends React.Component {
     const {
       classes, dropdownClass, localization, disableDropdown, native,
     } = this.props;
-
     const inputFlagClasses = `flag ${selectedCountry.iso2}`;
+
+    const isSelected = (country) => Boolean(selectedCountry && selectedCountry.dialCode === country.dialCode);
 
     const dropdownProps = disableDropdown ? {} : {
       startAdornment: (
@@ -671,63 +641,60 @@ class MaterialUiPhoneNumber extends React.Component {
                 ))}
               </NativeSelect>
             </>
-          ) : (
-            <>
-              <Button
-                className={classes.flagButton}
-                aria-owns={anchorEl ? 'country-menu' : null}
-                aria-label="Select country"
-                onClick={(e) => this.setState({ anchorEl: e.currentTarget })}
-                aria-haspopup
-              >
-                <div className={inputFlagClasses} />
-              </Button>
+          )
+            : (
+              <>
+                <Button
+                  className={classes.flagButton}
+                  aria-owns={anchorEl ? 'country-menu' : null}
+                  aria-label="Select country"
+                  onClick={(e) => this.setState({ anchorEl: e.currentTarget })}
+                  aria-haspopup
+                >
+                  <div className={inputFlagClasses} />
+                </Button>
 
-              <Menu
-                className={dropdownClass}
-                id="country-menu"
-                anchorEl={anchorEl}
-                open={Boolean(anchorEl)}
-                onClose={() => this.setState({ anchorEl: null })}
-                onEnter={this.handleFlagDropdownClick}
-                PaperProps={{
-                  ref: (node) => {
-                    this.dropdownContainerRef = node;
-                  },
-                }}
-              >
-                {!!preferredCountries.length && map(preferredCountries, (country, index) => (
-                  <Item
-                    key={`preferred_${country.iso2}_${index}`}
-                    itemRef={(node) => {
-                      this.flags[`flag_no_${index}`] = node;
-                    }}
-                    onClick={() => this.handleFlagItemClick(country)}
-                    name={country.name}
-                    iso2={country.iso2}
-                    dialCode={country.dialCode}
-                    localization={localization && localization[country.name]}
-                  />
-                ))}
+                <Menu
+                  className={dropdownClass}
+                  id="country-menu"
+                  anchorEl={anchorEl}
+                  open={Boolean(anchorEl)}
+                  onClose={() => this.setState({ anchorEl: null })}
+                >
+                  {!!preferredCountries.length && map(preferredCountries, (country, index) => (
+                    <Item
+                      key={`preferred_${country.iso2}_${index}`}
+                      itemRef={(node) => {
+                        this.flags[`flag_no_${index}`] = node;
+                      }}
+                      selected={isSelected(country)}
+                      onClick={() => this.handleFlagItemClick(country)}
+                      name={country.name}
+                      iso2={country.iso2}
+                      dialCode={country.dialCode}
+                      localization={localization && localization[country.name]}
+                    />
+                  ))}
 
-                {!!preferredCountries.length && <Divider />}
+                  {!!preferredCountries.length && <Divider />}
 
-                {map(onlyCountries, (country, index) => (
-                  <Item
-                    key={`preferred_${country.iso2}_${index}`}
-                    itemRef={(node) => {
-                      this.flags[`flag_no_${index}`] = node;
-                    }}
-                    onClick={() => this.handleFlagItemClick(country)}
-                    name={country.name}
-                    iso2={country.iso2}
-                    dialCode={country.dialCode}
-                    localization={localization && localization[country.name]}
-                  />
-                ))}
-              </Menu>
-            </>
-          )}
+                  {map(onlyCountries, (country, index) => (
+                    <Item
+                      key={`preferred_${country.iso2}_${index}`}
+                      itemRef={(node) => {
+                        this.flags[`flag_no_${index}`] = node;
+                      }}
+                      selected={isSelected(country)}
+                      onClick={() => this.handleFlagItemClick(country)}
+                      name={country.name}
+                      iso2={country.iso2}
+                      dialCode={country.dialCode}
+                      localization={localization && localization[country.name]}
+                    />
+                  ))}
+                </Menu>
+              </>
+            )}
         </InputAdornment>
       ),
     };
@@ -852,7 +819,7 @@ MaterialUiPhoneNumber.defaultProps = {
   localization: {},
 
   onEnterKeyPress: () => { },
-  onChange: () => {},
+  onChange: () => { },
 
   isModernBrowser: () => (document.createElement ? Boolean(document.createElement('input').setSelectionRange) : false),
 


### PR DESCRIPTION
Fix for issue https://github.com/alexplumb/material-ui-phone-number/issues/50

I have added the selected prop to the menu item which scrolls to the correct place in the list. 
I have remove the ref on the menu and the programmatic `scrollTo`. 
The selected props isn't used on the native select so I have not put on the items there. 

When an item is in the preferred and the main countries list both items are highlighted as selected and the list scrolls to the correct location in the main list. 

I have tested all the inputs on the `demo.jsx` manually and all seem to be work as I would expect. 

![Screenshot 2020-02-10 at 14 09 42](https://user-images.githubusercontent.com/20516520/74156852-17753880-4c0f-11ea-845f-9f5bb0cd2114.png)

 