### PR TITLE
Fix 'Cannot read property 'iso2' of undefined' issue

### DIFF
--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -588,7 +588,7 @@ class MaterialUiPhoneNumber extends React.Component {
     const {
       classes, dropdownClass, localization, disableDropdown, native,
     } = this.props;
-    const inputFlagClasses = `flag ${selectedCountry.iso2}`;
+    const inputFlagClasses = `flag ${selectedCountry && selectedCountry.iso2}`;
 
     const isSelected = (country) => Boolean(selectedCountry && selectedCountry.dialCode === country.dialCode);
 


### PR DESCRIPTION
Sometimes when selectedCountry doesn't exists appears issue.
Please take a look into this [github issue](https://github.com/bl00mber/react-phone-input-2/issues/60)