### PR TITLE
TypeError: Cannot read property 'focus' of null

### DIFF
--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -272,10 +272,12 @@ class MaterialUiPhoneNumber extends React.Component {
     const { isModernBrowser } = this.props;
 
     const input = this.inputRef;
-    input && input.focus();
-    if (isModernBrowser) {
-      const len = input.value.length;
-      input.setSelectionRange(len, len);
+    if (input) {
+      input.focus();
+      if (isModernBrowser) {
+        const len = input.value.length;
+        input.setSelectionRange(len, len);
+      }
     }
   }
 

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -272,7 +272,7 @@ class MaterialUiPhoneNumber extends React.Component {
     const { isModernBrowser } = this.props;
 
     const input = this.inputRef;
-    input.focus();
+    input && input.focus();
     if (isModernBrowser) {
       const len = input.value.length;
       input.setSelectionRange(len, len);


### PR DESCRIPTION
Sometimes this lib throws this error in our production code.
![image](https://user-images.githubusercontent.com/9931428/79545230-a4fe5a00-8090-11ea-88bb-f543cb223b07.png)

Here's code with usage of this lib in our app(nothing special though):

```jsx
const PhoneInput: React.FunctionComponent<PhoneInputProps> = ({
	defaultCountry,
	phoneNumber,
	onChange,
	className
}) => {
	const styles = useStyles();

	return (
		<MuiPhoneInput
			autoFocus
			id="filled-number"
			defaultCountry={defaultCountry}
			fullWidth
			disableAreaCodes
			label={<Translate label="sms.startWith" ns="player" />}
			margin="normal"
			variant="outlined"
			InputLabelProps={{
				shrink: true
			}}
			native={isMobile()}
			inputProps={{ shrink: true }}
			value={phoneNumber}
			onChange={onChange}
			inputClass={clsx(styles.phoneInput, className)}
			classes={{
				nativeSelect: styles.nativeInput,
				flagButton: styles.flagButton
			}}
		/>
	);
};
```