### PR TITLE
change react dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,11 +57,11 @@
   "dependencies": {
     "clsx": "^1.0.4",
     "lodash": "^4.17.14",
-    "prop-types": "^15.7.2",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.2.1"
+    "@material-ui/core": "^4.2.1",
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   }
 }


### PR DESCRIPTION
move react and react-dom dependencies to peerDependency and use greater or equal (support react 17 and 18) to prevent installing multiple versions of react