### PR TITLE
correct Swedish phone number format

### DIFF
--- a/src/country_data.js
+++ b/src/country_data.js
@@ -1309,7 +1309,7 @@ const rawAllCountries = [
     ['europe', 'european-union'],
     'se',
     '46',
-    '+.. (..) ...-..-..',
+    '+.. ..-... .. ..',
   ],
   [
     'Switzerland',


### PR DESCRIPTION
The current formatting of the Swedish phone numbers are not the common way they are currently formatted. The most common way to write it is +46 70-123 45 67 or +46 (0)70-123 45 67. Since the current formatting doesn't include 0, the first alternative formatting seems more appropriate.