### PR TITLE
Fix flags for firefox and safari

### DIFF
--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -18,6 +18,7 @@ import Item from './Item';
 
 const styles = () => ({
   flagButton: {
+    width: 'min-content',
     minWidth: 30,
     padding: 0,
     height: 30,

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -22,6 +22,9 @@ const styles = () => ({
     minWidth: 30,
     padding: 0,
     height: 30,
+    '& svg': {
+      width: 'fill-available',
+    },
   },
   flagIcon: {
     width: 16,


### PR DESCRIPTION
Fixes 2 bugs:
- #110 Full page flag in firefox
- #111 No flag in safari

I was not able to run this locally, but I tested by using these overrides in my code :shrug:
Webpack wasn't able to find @mui/styles and react