### PR TITLE
fix: missing API props - localization

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ export type MuiPhoneNumberProps = TextFieldProps & {
   dropdownClass?: string;
   enableLongNumbers?: boolean;
   excludeCountries?: string[];
+  localization?: Record<string, string>;
   inputClass?: string;
   onChange: (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | string


### PR DESCRIPTION
I added the missing prop type `localization` for a `MuiPhoneNumber` component.