### PR TITLE
add typescript support for onChange method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,12 @@
 import { TextFieldProps } from "@mui/material";
 import * as React from "react";
 
+type Country = {
+  name: string;
+  dialCode: string;
+  countryCode: string;
+}
+
 export type MuiPhoneNumberProps = TextFieldProps & {
   autoFormat?: boolean;
   classes?: any;
@@ -13,9 +19,7 @@ export type MuiPhoneNumberProps = TextFieldProps & {
   enableLongNumbers?: boolean;
   excludeCountries?: string[];
   inputClass?: string;
-  onChange: (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | string
-  ) => void;
+  onChange: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement> & ((mobileNumber: string, country: Country) => void);
   onlyCountries?: string[];
   preferredCountries?: string[];
   regions?: [string] | string;


### PR DESCRIPTION
The onChange method is providing us mobile number and country info on the first and second param but the type definition includes only one event param due to which the users are unable to access the second param and are getting this error
![image](https://user-images.githubusercontent.com/35004754/148546036-d067c1a8-e278-4ddc-9b91-929fa32e8b8f.png)
So in order to overcome this error, I have added the type definition for the onChange method as 
```
  onChange: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement> & ((mobileNumber: string, country: Country) => void);

```
and the type definition for the country (second param) as
```
type Country = {
  name: string;
  dialCode: string;
  countryCode: string;
}
```
After this, the user can access both params successfully without any ts errors
![image](https://user-images.githubusercontent.com/35004754/148549821-b3d655b4-7437-4f5a-8663-d43601d310d2.png)


