### PR TITLE
Fixed a bug country code can be changed when countryCodeEditable is false.

### DIFF
--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -312,7 +312,7 @@ class MaterialUiPhoneNumber extends React.Component {
 
     if (!countryCodeEditable) {
       const updatedInput = `+${newSelectedCountry.dialCode}`;
-      if (e.target.value.length < updatedInput.length) {
+      if (!e.target.value.startsWith(updatedInput)) {
         return;
       }
     }


### PR DESCRIPTION
When countryCodeEditable is false, the country code cannot be deleted. It is normal until here. However, if we start typing numbers after clicking the country code with the mouse cursor, we can change the country code. This pr solves this bug.