### PR TITLE
Change country Togo format

### DIFF
--- a/src/country_data.js
+++ b/src/country_data.js
@@ -1359,7 +1359,7 @@ const rawAllCountries = [
     ['africa'],
     'tg',
     '228',
-    '+... ... .....',
+    '+... .. .. .. ..',
   ],
   [
     'Tokelau',


### PR DESCRIPTION
Format used for the Togo country is a little weird as it is common to spell and write our numbers as 90 00 00 00 and not 900 00000. So this brings a lot confusion for non warned users.